### PR TITLE
Make option for both email and er alerts

### DIFF
--- a/cougarvision_utils/alert.py
+++ b/cougarvision_utils/alert.py
@@ -35,7 +35,7 @@ def smtp_setup(username, password, host):
     return smtp_server
 
 
-def send_alert(alert, img, smtp_server, from_email, to_emails):
+def send_alert(alert, img, smtp_server, from_email, to_emails, dev, conf):
     '''Send Alert
 
     This function takes in the animal label, the image of the animal of
@@ -58,11 +58,16 @@ def send_alert(alert, img, smtp_server, from_email, to_emails):
     email_message.add_header('From', from_email)
     email_message.add_header('Subject', 'Alert!')
     email_message.add_header('X-Priority', '1')  # Urgency, 1 highest, 5 lowest
-    message = "Potential " + alert + " detected by CougarVision "\
-              + "system.\n\nPlease review attached image to verify detection."\
-              + " Cougarvision is set to be sensitive to avoid missing "\
-              + "species of interest so other animals and artifacts have been"\
-              + " known to trigger the system."
+    if dev == 0:
+        message = "Potential " + alert + " detected by CougarVision "\
+                  + "system.\n\nPlease review attached image to verify"\
+                  + " detection. Cougarvision is set to be sensitive to"\
+                  + " avoid missing species of interest so other animals "\
+                  + "and artifacts have been known to trigger the system."
+    elif dev != 0:
+        message = "Potential " + alert + " detected with confidence value: "\
+                  + conf
+
     email_message.set_content(message)
 
     # Prepare Image format

--- a/cougarvision_utils/detect_img.py
+++ b/cougarvision_utils/detect_img.py
@@ -46,7 +46,8 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
     targets = config['alert_targets']
     username = config['username']
     password = config['password']
-    to_emails = config['to_emails']
+    consumer_emails = config['consumer_emails']
+    dev_emails = config['dev_emails']
     host = 'imap.gmail.com'
     token = config['token']
     authorization = config['authorization']
@@ -90,8 +91,7 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
                 # Sends alert for each cougar detection
                 for idx in range(len(cougars.index)):
                     label = cougars.at[idx, 'class']
-                    # uncomment this line to use conf value for dev email alert
-                    # prob = cougars.at[idx, 'conf']
+                    prob = str(cougars.at[idx, 'conf'])
                     img = Image.open(cougars.at[idx, 'file'])
                     draw_bounding_box_on_image(img,
                                                cougars.at[idx, 'bbox2'],
@@ -126,8 +126,12 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
                         print(response)
                     if email_alerts is True:
                         smtp_server = smtp_setup(username, password, host)
+                        dev = 0
                         send_alert(label, image_bytes, smtp_server,
-                                   username, to_emails)
+                                   username, consumer_emails, dev, prob)
+                        dev = 1
+                        send_alert(label, image_bytes, smtp_server,
+                                   username, dev_emails, dev, prob)
                 # Write Dataframe to csv
                 date = "%m-%d-%Y_%H:%M:%S"
                 cougars.to_csv(f'{log_dir}dataframe_{dt.now().strftime(date)}')

--- a/cougarvision_utils/detect_img.py
+++ b/cougarvision_utils/detect_img.py
@@ -35,7 +35,8 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
         necessary parameters the function needs
     '''
     detector_model = config['detector_model']
-    use_variation = int(config['use_variation'])
+    email_alerts = bool(config['email_alerts'])
+    er_alerts = bool(config['er_alerts'])
     classifier_model = config['classifier_model']
     model = keras.models.load_model(classifier_model)
     log_dir = config['log_dir']
@@ -112,7 +113,7 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
                     if label in targets:
                         is_target(cam_name, token, authorization, label)
                     # Email or Earthranger alerts as dictated in the config yml
-                    if use_variation == 2:
+                    if er_alerts is True:
                         event_id = post_event(label,
                                               cam_name,
                                               token,
@@ -123,7 +124,7 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
                                                 authorization,
                                                 label)
                         print(response)
-                    else:
+                    if email_alerts is True:
                         smtp_server = smtp_setup(username, password, host)
                         send_alert(label, image_bytes, smtp_server,
                                    username, to_emails)

--- a/cougarvision_utils/detect_img.py
+++ b/cougarvision_utils/detect_img.py
@@ -110,7 +110,7 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
                     img.save(image_bytes, format="JPEG")
                     img_byte = image_bytes.getvalue()
                     cam_name = cougars.at[idx, 'cam_name']
-                    if label in targets:
+                    if label in targets and er_alerts is True:
                         is_target(cam_name, token, authorization, label)
                     # Email or Earthranger alerts as dictated in the config yml
                     if er_alerts is True:

--- a/cougarvision_utils/get_images.py
+++ b/cougarvision_utils/get_images.py
@@ -69,6 +69,7 @@ def request_strikeforce(username, auth_token, base, request, parameters):
     call = base + request + "?" + parameters
     response = requests.get(call, headers={"X-User-Email": username,
                                            "X-User-Token": auth_token})
+    print(response.text)
     info = json.loads(response.text)
     return info
 
@@ -86,9 +87,10 @@ def fetch_image_api(config):
     '''
     camera_names = dict(config['camera_names'])
     base = config['strikeforce_api']
-    username = config['username_scraper']
-    auth_token = config['auth_token']
+    account1, account2 = config['username_scraper']
+    token1, token2 = config['auth_token']
     path = "./last_id.txt"
+    password = config['password_scraper']
     checkfile = os.path.exists(path)
     if checkfile is False:
         new_file = open("last_id.txt", "x")
@@ -106,9 +108,11 @@ def fetch_image_api(config):
     id_file.close()
 
 # 5 second delay between captures, maximum 12 photos between checks
-    data = request_strikeforce(username, auth_token, base,
+    data = request_strikeforce(account1, token1, base,
                                "photos/recent", "limit=12")
-    photos = data['photos']['data']
+    data2 = request_strikeforce(account2, token2, base,
+                               "photos/recent", "limit=12")
+    photos = data['photos']['data'] + data2['photos']['data']
 
     new_photos = []
     for i in range(len(photos)):
@@ -116,9 +120,10 @@ def fetch_image_api(config):
             info = photos[i]['attributes']
             print(info)
             camera = camera_names[photos[i]['relationships']
-                                  ['camera']['data']['id']]
+                                 ['camera']['data']['id']]
             newname = config['save_dir'] + camera
             newname += "_" + info['file_thumb_filename']
+            print(newname)
             urllib.request.urlretrieve(info['file_thumb_url'], newname)
             new_photos.append([photos[i]['id'],
                                info['file_thumb_url'], newname])

--- a/cougarvision_utils/get_images.py
+++ b/cougarvision_utils/get_images.py
@@ -87,8 +87,8 @@ def fetch_image_api(config):
     '''
     camera_names = dict(config['camera_names'])
     base = config['strikeforce_api']
-    account1, account2 = config['username_scraper']
-    token1, token2 = config['auth_token']
+    accounts = config['username_scraper']
+    tokens = config['auth_token']
     path = "./last_id.txt"
     password = config['password_scraper']
     checkfile = os.path.exists(path)
@@ -106,13 +106,12 @@ def fetch_image_api(config):
         line.strip()
     last_id = int(line)
     id_file.close()
-
+    photos = []
 # 5 second delay between captures, maximum 12 photos between checks
-    data = request_strikeforce(account1, token1, base,
-                               "photos/recent", "limit=12")
-    data2 = request_strikeforce(account2, token2, base,
-                               "photos/recent", "limit=12")
-    photos = data['photos']['data'] + data2['photos']['data']
+    for account, token in zip(accounts, tokens):
+        data = request_strikeforce(account, token, base,
+                                   "photos/recent", "limit=12")
+        photos += data['photos']['data']
 
     new_photos = []
     for i in range(len(photos)):

--- a/fetch_and_alert.py
+++ b/fetch_and_alert.py
@@ -43,7 +43,7 @@ with open(CONFIG_FILE, 'r', encoding='utf-8') as stream:
 # Set Email Variables for fetching
 USERNAME = CONFIG['username']
 PASSWORD = CONFIG['password']
-TO_EMAILS = CONFIG['to_emails']
+DEV_EMAILS = CONFIG['dev_emails']
 HOST = 'imap.gmail.com'
 
 
@@ -68,7 +68,7 @@ def main():
     ''''Runs main program and schedules future runs'''
     fetch_detect_alert()
     schedule.every(10).minutes.do(fetch_detect_alert)
-    schedule.every(CHECKIN_INTERVAL).hours.do(checkin, TO_EMAILS,
+    schedule.every(CHECKIN_INTERVAL).hours.do(checkin, DEV_EMAILS,
                                               USERNAME, PASSWORD, HOST)
 
     while True:


### PR DESCRIPTION
Previously, you had to choose if you wanted earthranger alerts or email alerts, but now you can do both or neither or one or the other by changing the config .yml.

Resolves #31