### PR TITLE
Load models once, reuse after sleep from preloaded model

### DIFF
--- a/cougarvision_utils/detect_img.py
+++ b/cougarvision_utils/detect_img.py
@@ -16,10 +16,9 @@ import yaml
 import sys
 import yolov5
 from PIL import Image
-from tensorflow import keras
 from animl import parseResults, imageCropGenerator, splitData, detectMD
 from sageranger import is_target, attach_image, post_event
-from animl.detectMD import load_MD_model, detect_MD_batch
+from animl.detectMD import detect_MD_batch
 
 from cougarvision_utils.cropping import draw_bounding_box_on_image
 from cougarvision_utils.alert import smtp_setup, send_alert
@@ -29,7 +28,8 @@ with open("config/cameratraps.yml", 'r') as stream:
     camera_traps_config = yaml.safe_load(stream)
     sys.path.append(camera_traps_config['camera_traps_path'])
 
-def detect(images, config):  # pylint: disable-msg=too-many-locals
+
+def detect(images, config, c_model, d_model):
     '''
     This function takes in a dataframe of images and runs a detector model,
     classifies the species of interest, and sends alerts either to email or an
@@ -42,12 +42,9 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
     config: the unpacked config values from fetch_and_alert.yml that contains
         necessary parameters the function needs
     '''
-    detector_model = config['detector_model']
     use_variation = int(config['use_variation'])
-    classifier_model = config['classifier_model']
-    model = keras.models.load_model(classifier_model)
     log_dir = config['log_dir']
-    checkpoint_frequency = config['checkpoint_frequency']
+    checkpoint_f = config['checkpoint_frequency']
     confidence = config['confidence']
     classes = config['classes']
     targets = config['alert_targets']
@@ -61,34 +58,37 @@ def detect(images, config):  # pylint: disable-msg=too-many-locals
         # extract paths from dataframe
         image_paths = images[:, 2]
         # Run Detection
-        loaded_model = load_MD_model(detector_model)                                                    
-        results = detect_MD_batch(loaded_model,
+        results = detect_MD_batch(d_model,
                                   image_paths,
                                   checkpoint_path=None,
                                   confidence_threshold=confidence,
-                                  checkpoint_frequency=-1,
+                                  checkpoint_frequency=checkpoint_f,
                                   results=None,
                                   n_cores=1,
                                   quiet=False,
                                   image_size=None)
-        # Parse results                                                           
+        # Parse results
         data_frame = parseResults.parseMD(results, None, None)
         # filter out all non animal detections
         if not data_frame.empty:
-            animal_df= splitData.getAnimals(data_frame)   
-            otherdf = splitData.getEmpty(data_frame)           ###new function: split file
+            animal_df = splitData.getAnimals(data_frame)
+            otherdf = splitData.getEmpty(data_frame)
             # run classifier on animal detections if there are any
             if not animal_df.empty:
                 # create generator for images
 
                 generator = imageCropGenerator.\
-                    GenerateCropsFromFile(animal_df)                            ### changed function
+                    GenerateCropsFromFile(animal_df)  # changed function
                 # Run Classifier
-                predictions = model.predict_generator(generator,
-                                                      steps=len(generator),
-                                                      verbose=1)                                    
+                predictions = c_model.predict_generator(generator,
+                                                        steps=len(generator),
+                                                        verbose=1)
                 # Parse results
-                max_df = parseResults.applyPredictions(animal_df, predictions, classes, None, False)
+                max_df = parseResults.applyPredictions(animal_df,
+                                                       predictions,
+                                                       classes,
+                                                       None,
+                                                       False)
                 # Creates a data frame with all relevant data
                 cougars = max_df[max_df['prediction'].isin(targets)]
                 # drops all detections with confidence less than threshold

--- a/fetch_and_alert.py
+++ b/fetch_and_alert.py
@@ -27,6 +27,8 @@ import schedule
 from cougarvision_utils.detect_img import detect
 from cougarvision_utils.alert import checkin
 from cougarvision_utils.get_images import fetch_image_api
+from animl.predictSpecies import load_classifier
+from animl.detectMD import load_MD_model
 
 
 # Numpy FutureWarnings from tensorflow import
@@ -44,11 +46,17 @@ with open(CONFIG_FILE, 'r', encoding='utf-8') as stream:
 USERNAME = CONFIG['username']
 PASSWORD = CONFIG['password']
 TO_EMAILS = CONFIG['to_emails']
+CLASSIFIER = CONFIG['classifier_model']
+DETECTOR = CONFIG['detector_model']
 HOST = 'imap.gmail.com'
 
 
 # Set interval for checking in
 CHECKIN_INTERVAL = CONFIG['checkin_interval']
+
+# load models once
+CLASSIFIER_MODEL = load_classifier(CLASSIFIER)
+DETECTOR_MODEL = load_MD_model(DETECTOR)
 
 
 def fetch_detect_alert():
@@ -59,7 +67,7 @@ def fetch_detect_alert():
     images = fetch_image_api(CONFIG)
     print('Finished fetching images')
     print('Starting Detection')
-    detect(images, CONFIG)
+    detect(images, CONFIG, CLASSIFIER_MODEL, DETECTOR_MODEL)
     print('Finished Detection')
     print("Sleeping since: " + str(dt.now()))
 


### PR DESCRIPTION
This revision loads both the detector and classifer models once upon first starting the program in fetch_and_alert.py and then passes the loaded models to detect_img.py so it doesn't load them both each time. These loading functions come from the animl-py module, currently specifically the "model_load" branch within githib.

Resolves #39