### PR TITLE
Add logging and error exception for camera ID's not in config

### DIFF
--- a/cougarvision_utils/get_images.py
+++ b/cougarvision_utils/get_images.py
@@ -17,6 +17,7 @@ import urllib.request
 import os.path
 import requests
 import numpy as np
+import logging
 
 
 '''
@@ -118,8 +119,13 @@ def fetch_image_api(config):
         if int(photos[i]['id']) > last_id:
             info = photos[i]['attributes']
             print(info)
-            camera = camera_names[photos[i]['relationships']
-                                 ['camera']['data']['id']]
+            try:
+                camera = camera_names[photos[i]['relationships']
+                                     ['camera']['data']['id']]
+            except KeyError:
+                logging.warning('Cannot retrieve photo from camera\
+                as there is no asssociated ID in the config file')
+                continue
             newname = config['save_dir'] + camera
             newname += "_" + info['file_thumb_filename']
             print(newname)

--- a/fetch_and_alert.py
+++ b/fetch_and_alert.py
@@ -24,6 +24,7 @@ import warnings
 from datetime import datetime as dt
 import yaml
 import schedule
+import logging
 
 from cougarvision_utils.detect_img import detect
 from cougarvision_utils.alert import checkin
@@ -47,7 +48,6 @@ with open(CONFIG_FILE, 'r', encoding='utf-8') as stream:
 # Set Email Variables for fetching
 USERNAME = CONFIG['username']
 PASSWORD = CONFIG['password']
-TO_EMAILS = CONFIG['to_emails']
 TOKEN = CONFIG['token']
 AUTH = CONFIG['authorization']
 CLASSIFIER = CONFIG['classifier_model']
@@ -62,6 +62,10 @@ CHECKIN_INTERVAL = CONFIG['checkin_interval']
 # load models once
 CLASSIFIER_MODEL = load_classifier(CLASSIFIER)
 DETECTOR_MODEL = load_MD_model(DETECTOR)
+
+
+def logger():
+    logging.basicConfig(filename='cougarvision.log', level=logging.INFO)
 
 
 def fetch_detect_alert():
@@ -79,6 +83,7 @@ def fetch_detect_alert():
 
 def main():
     ''''Runs main program and schedules future runs'''
+    logger()
     fetch_detect_alert()
     schedule.every(10).minutes.do(fetch_detect_alert)
     schedule.every(CHECKIN_INTERVAL).hours.do(checkin, DEV_EMAILS,


### PR DESCRIPTION
For demo purposes as well as robustness of the software, cougarvision needs to be able to handle circumstances when the config file camera IDs don't contain all the cameras that may be sending photos to strikeforce. Now, get_images will log a warning in the cougarvision.log file that alerts the user if there was a photo retrived from a camera it doesn't regognize so that ID can be added, without it crashing the whole program and allowing it to continue to run. It also doesn't muddy up the terminal when running a demo, as most camera images are skipped in that circumstance

Resolves #41